### PR TITLE
🔒️ Update NuGet source to Azure Devops version

### DIFF
--- a/Source/NuGet.Config
+++ b/Source/NuGet.Config
@@ -8,6 +8,6 @@
     <add key="automatic" value="True" />
   </packageRestore>
   <packageSources>
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="InnerEye_UI" value="https://innereye.pkgs.visualstudio.com/InnerEye/_packaging/InnerEye_UI/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
The current NuGet source causes the build pipeline to fail as external sources are not permitted under the current security rules. This PR updates that source so that the pipeline can pass and other PRs can be merged.